### PR TITLE
feat(security): add role-based HTTP Basic authentication with 3 roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ logs/
 Thumbs.db
 *.tmp
 *.swp
+META-INF/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MoneyTrak - Expense Tracking API
 
-A Spring Boot REST API for tracking expenses with validation, optimistic locking, and comprehensive error handling.
+A Spring Boot REST API for tracking expenses with validation.
 
 ## Features
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,19 @@
 			<groupId>org.flywaydb</groupId>
 			<artifactId>flyway-core</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/specs/002-transaction-categories/quickstart.md
+++ b/specs/002-transaction-categories/quickstart.md
@@ -173,7 +173,7 @@ curl -X POST http://localhost:8080/v1/transactions \
     "currency": "EUR",
     "date": "2026-01-19T10:00:00Z",
     "transactionType": "EXPENSE",
-    "transactionStability": "VARIABLE",
+    "stability": "VARIABLE",
     "categoryId": "550e8400-e29b-41d4-a716-446655440000"
   }' | jq
 ```
@@ -209,7 +209,7 @@ curl -X POST http://localhost:8080/v1/transactions \
     "currency": "EUR",
     "date": "2026-01-01T00:00:00Z",
     "transactionType": "EXPENSE",
-    "transactionStability": "FIXED",
+    "stability": "FIXED",
     "categoryId": "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
   }' | jq
 ```
@@ -227,7 +227,7 @@ curl -X POST http://localhost:8080/v1/transactions \
     "currency": "EUR",
     "date": "2026-01-01T00:00:00Z",
     "transactionType": "INCOME",
-    "transactionStability": "FIXED"
+    "stability": "FIXED"
   }' | jq
 ```
 
@@ -246,7 +246,7 @@ curl -X POST http://localhost:8080/v1/transactions \
     "currency": "EUR",
     "date": "2026-01-15T00:00:00Z",
     "transactionType": "INCOME",
-    "transactionStability": "VARIABLE",
+    "stability": "VARIABLE",
     "categoryId": "7c9e6679-7425-40de-944b-e07fc1f90ae7"
   }' | jq
 ```
@@ -325,7 +325,7 @@ curl -X PUT "http://localhost:8080/v1/transactions/${TRANSACTION_ID}" \
     "currency": "EUR",
     "date": "2026-01-19T10:00:00Z",
     "transactionType": "EXPENSE",
-    "transactionStability": "VARIABLE",
+    "stability": "VARIABLE",
     "categoryId": "550e8400-e29b-41d4-a716-446655440000",
     "version": 0
   }' | jq
@@ -377,7 +377,7 @@ curl -X POST http://localhost:8080/v1/transactions \
     "currency": "EUR",
     "date": "2026-01-19T10:00:00Z",
     "transactionType": "EXPENSE",
-    "transactionStability": "VARIABLE"
+    "stability": "VARIABLE"
   }' | jq
 ```
 
@@ -409,7 +409,7 @@ curl -X POST http://localhost:8080/v1/transactions \
     "currency": "EUR",
     "date": "2027-01-01T00:00:00Z",
     "transactionType": "EXPENSE",
-    "transactionStability": "VARIABLE"
+    "stability": "VARIABLE"
   }' | jq
 ```
 
@@ -441,7 +441,7 @@ curl -X POST http://localhost:8080/v1/transactions \
     "currency": "INVALID",
     "date": "2026-01-19T10:00:00Z",
     "transactionType": "EXPENSE",
-    "transactionStability": "VARIABLE"
+    "stability": "VARIABLE"
   }' | jq
 ```
 
@@ -512,7 +512,7 @@ curl -X PUT "http://localhost:8080/v1/transactions/${TRANSACTION_ID}" \
     "currency": "EUR",
     "date": "2026-01-19T10:00:00Z",
     "transactionType": "EXPENSE",
-    "transactionStability": "VARIABLE",
+    "stability": "VARIABLE",
     "categoryId": "550e8400-e29b-41d4-a716-446655440000",
     "version": 0
   }' | jq
@@ -575,7 +575,7 @@ curl -X POST http://localhost:8080/v1/transactions \
     "currency": "EUR",
     "date": "2026-01-01T00:00:00Z",
     "transactionType": "INCOME",
-    "transactionStability": "FIXED"
+    "stability": "FIXED"
   }'
 
 # 5. View all transactions

--- a/specs/003-simple-auth/checklists/requirements.md
+++ b/specs/003-simple-auth/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Simple Role-Based Authentication
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-02-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items passed validation on first iteration.
+- Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/003-simple-auth/contracts/security-rules.md
+++ b/specs/003-simple-auth/contracts/security-rules.md
@@ -1,0 +1,108 @@
+# Security Rules Contract: Simple Role-Based Authentication
+
+**Feature Branch**: `003-simple-auth`
+**Date**: 2026-02-03
+
+## Overview
+
+This feature adds HTTP Basic Authentication to all existing endpoints. No new API endpoints are introduced. The contract below defines the security behavior layered on top of existing endpoint contracts.
+
+## Authentication
+
+**Mechanism**: HTTP Basic Authentication
+**Header**: `Authorization: Basic <base64(username:password)>`
+
+### Unauthenticated Responses
+
+All protected endpoints return 401 when credentials are missing or invalid.
+
+**Response** (401 Unauthorized):
+```json
+{
+  "status": 401,
+  "error": "Unauthorized",
+  "message": "Authentication required. Provide valid credentials.",
+  "details": []
+}
+```
+
+**Response headers**: `WWW-Authenticate: Basic realm="MoneyTrak API"`
+
+### Forbidden Responses
+
+Authenticated users without sufficient permissions receive 403.
+
+**Response** (403 Forbidden):
+```json
+{
+  "status": 403,
+  "error": "Forbidden",
+  "message": "Access denied. Insufficient permissions for this operation.",
+  "details": []
+}
+```
+
+## Authorization Rules
+
+### Public Endpoints (No Authentication Required)
+
+| Endpoint             | Method | Description        |
+| -------------------- | ------ | ------------------ |
+| /actuator/health     | GET    | Health check       |
+
+### APP Role (Read-Only)
+
+| Endpoint                            | Method | Description               |
+| ----------------------------------- | ------ | ------------------------- |
+| /v1/transactions                    | GET    | List transactions         |
+| /v1/transactions/{id}               | GET    | Get transaction           |
+| /v1/transactions/summary/expenses   | GET    | Expense total             |
+| /v1/transactions/summary/income     | GET    | Income total              |
+| /v1/categories                      | GET    | List categories           |
+| /v1/categories/{id}                 | GET    | Get category              |
+
+### BACKOFFICE Role (Full CRUD)
+
+*Includes all APP permissions plus:*
+
+| Endpoint                    | Method | Description            |
+| --------------------------- | ------ | ---------------------- |
+| /v1/transactions            | POST   | Create transaction     |
+| /v1/transactions/{id}       | PUT    | Update transaction     |
+| /v1/transactions/{id}       | DELETE | Delete transaction     |
+| /v1/categories              | POST   | Create category        |
+| /v1/categories/{id}         | PUT    | Update category        |
+| /v1/categories/{id}         | DELETE | Delete category        |
+
+### ADMIN Role (Full Access)
+
+*Includes all BACKOFFICE permissions plus:*
+
+| Endpoint                    | Method | Description                |
+| --------------------------- | ------ | -------------------------- |
+| /actuator/info              | GET    | Application info           |
+| /actuator/*                 | GET    | All actuator endpoints     |
+| /h2-console/**              | ANY    | Database console access    |
+
+## Logging Contract
+
+### Failed Authentication Logging (FR-014)
+
+Every failed authentication attempt MUST produce a log entry containing:
+
+| Field     | Description                              | Example                    |
+| --------- | ---------------------------------------- | -------------------------- |
+| username  | The attempted username                   | `unknown-user`             |
+| timestamp | ISO 8601 timestamp of the attempt        | `2026-02-03T14:30:00.000Z` |
+| ip        | Client IP address from request           | `192.168.1.100`            |
+| level     | Log level                                | `WARN`                     |
+
+**Log format**: `WARN - Failed authentication attempt: username='{}', ip='{}', timestamp='{}'`
+
+## Behavior Changes to Existing Endpoints
+
+No functional changes to existing endpoint behavior. The only additions are:
+1. All requests require valid HTTP Basic credentials (except health).
+2. Write operations require BACKOFFICE or ADMIN role.
+3. Read operations require any valid role.
+4. Error responses for 401/403 follow the existing `ErrorResponseDto` format.

--- a/specs/003-simple-auth/data-model.md
+++ b/specs/003-simple-auth/data-model.md
@@ -1,0 +1,70 @@
+# Data Model: Simple Role-Based Authentication
+
+**Feature Branch**: `003-simple-auth`
+**Date**: 2026-02-03
+
+## Overview
+
+This feature does **not** introduce new database entities. Users are defined in application configuration, not persisted to the database. The data model consists of configuration-bound objects and Spring Security's in-memory `UserDetails` representations.
+
+## Entities
+
+### ConfigUser (Configuration-Bound)
+
+Represents a user defined in `application.yaml`, bound via `@ConfigurationProperties`.
+
+| Field    | Type   | Constraints                                    | Description                    |
+| -------- | ------ | ---------------------------------------------- | ------------------------------ |
+| username | String | Required, non-blank                            | Unique identifier for the user |
+| password | String | Required, non-blank, BCrypt-hashed with prefix | Encoded password               |
+| role     | String | Required, one of: APP, BACKOFFICE, ADMIN       | User's permission level        |
+
+**Notes**:
+- Passwords stored with `{bcrypt}` prefix for `DelegatingPasswordEncoder` compatibility.
+- Role is case-insensitive in configuration but mapped to uppercase internally.
+- No database table — purely configuration-driven.
+
+### Role (Enum)
+
+Defines the three permission levels in the system.
+
+| Value      | Description                                                   |
+| ---------- | ------------------------------------------------------------- |
+| APP        | Read-only access to transactions and categories               |
+| BACKOFFICE | Full CRUD access to transactions and categories               |
+| ADMIN      | Full CRUD access + actuator endpoints + H2 console access     |
+
+**Hierarchy**: ADMIN > BACKOFFICE > APP (each higher role includes all lower-role permissions for `/v1/**` endpoints).
+
+### Role Permission Mapping
+
+| HTTP Method | /v1/** endpoints | /actuator/health | /actuator/* (other) | /h2-console |
+| ----------- | ---------------- | ---------------- | ------------------- | ----------- |
+| GET         | APP+             | Public           | ADMIN only          | ADMIN only  |
+| POST        | BACKOFFICE+      | N/A              | N/A                 | N/A         |
+| PUT         | BACKOFFICE+      | N/A              | N/A                 | N/A         |
+| DELETE      | BACKOFFICE+      | N/A              | N/A                 | N/A         |
+
+*"APP+" means APP, BACKOFFICE, and ADMIN. "BACKOFFICE+" means BACKOFFICE and ADMIN.*
+
+## Configuration Schema
+
+```yaml
+moneytrak:
+  security:
+    users:
+      - username: <string>
+        password: <string>    # {bcrypt}$2a$10$...
+        role: <APP|BACKOFFICE|ADMIN>
+```
+
+## Relationships to Existing Entities
+
+- No foreign keys added to `transactions` or `categories` tables.
+- No database migration required (no V3 migration).
+- Authentication is stateless — no session table needed.
+- User identity is not associated with individual transactions (out of scope for this feature).
+
+## State Transitions
+
+N/A — no entity lifecycle management. Users are static configuration.

--- a/specs/003-simple-auth/plan.md
+++ b/specs/003-simple-auth/plan.md
@@ -1,0 +1,117 @@
+# Implementation Plan: Simple Role-Based Authentication
+
+**Branch**: `003-simple-auth` | **Date**: 2026-02-04 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/003-simple-auth/spec.md`
+
+## Summary
+
+Add HTTP Basic Authentication with three roles (APP, BACKOFFICE, ADMIN) to secure all existing MoneyTrak API endpoints. Users are defined in application configuration (not database). APP gets read-only access, BACKOFFICE gets full CRUD, ADMIN gets CRUD + actuator endpoints. Health check remains public. Error responses match existing `ErrorResponseDto` format.
+
+## Technical Context
+
+**Language/Version**: Java 25
+**Primary Dependencies**: Spring Boot 4.0.1, Spring Security 7.0.2 (via `spring-boot-starter-security`), Spring Web MVC, Spring Data JPA, Jakarta Validation
+**Storage**: H2 (file-based production, in-memory tests) — no schema changes for this feature
+**Testing**: `./mvnw test` — JUnit 5 + MockMvc + `spring-security-test` (`@WithMockUser`, `httpBasic()`)
+**Target Platform**: JVM (server-side REST API)
+**Project Type**: Single Spring Boot application
+**Performance Goals**: N/A — security layer adds negligible overhead for in-memory user lookup
+**Constraints**: No database migration required. No new API endpoints. Configuration-only users (< 10).
+**Scale/Scope**: 3 users, 3 roles, 5 security classes, ~6 existing test files to update, 1 new test file
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Feature-Based Architecture | PASS | Security classes go in `dev.juanvaldivia.moneytrak.security` package (infrastructure concern, permitted by constitution) |
+| II. DTO Pattern & Clean Contracts | PASS | Error responses reuse existing `ErrorResponseDto` record. No new DTOs needed. |
+| III. Test-Driven Development | PASS | New `SecurityIntegrationTest` covers all role/endpoint combinations. Existing tests updated with `@WithMockUser`. TDD cycle: tests written first for security scenarios. |
+| IV. API Versioning & Compatibility | PASS | No new endpoints introduced. No breaking changes to existing endpoints. Security is an additive layer. |
+| V. Type Safety & Validation | PASS | `SecurityProperties` is a type-safe `@ConfigurationProperties` record. Role names validated via configuration binding. |
+| Configuration Management | PASS | Users defined in `application.yaml` with BCrypt-hashed passwords. Test profile uses `{noop}` for readability. No hardcoded credentials in source. |
+
+**Pre-Phase 0 Gate**: PASS
+**Post-Phase 1 Gate**: PASS — Design aligns with all constitution principles.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-simple-auth/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (complete)
+├── data-model.md        # Phase 1 output (complete)
+├── quickstart.md        # Phase 1 output (complete)
+├── contracts/
+│   └── security-rules.md  # Phase 1 output (complete)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+src/main/java/dev/juanvaldivia/moneytrak/
+├── security/
+│   ├── SecurityConfig.java              # SecurityFilterChain bean with URL-based rules
+│   ├── SecurityProperties.java          # @ConfigurationProperties record for user config
+│   ├── SecurityUserDetailsService.java  # Maps config users → InMemoryUserDetailsManager
+│   ├── CustomAuthEntryPoint.java        # JSON 401 response handler + failed auth logging
+│   └── CustomAccessDeniedHandler.java   # JSON 403 response handler
+├── exception/
+│   └── ErrorResponseDto.java            # Existing — reused by auth handlers
+├── transactions/
+│   └── TransactionController.java       # Existing — no changes needed
+└── categories/
+    └── CategoryController.java          # Existing — no changes needed
+
+src/main/resources/
+├── application.yaml                     # Updated: moneytrak.security.users config block
+└── application-test.yaml                # Updated: test users with {noop} passwords
+
+src/test/java/dev/juanvaldivia/moneytrak/
+├── security/
+│   └── SecuritySmokeTest.java           # Existing smoke test (2 tests)
+│   └── SecurityIntegrationTest.java     # NEW: comprehensive role-based tests
+├── transactions/
+│   └── TransactionControllerTest.java   # Updated: @WithMockUser(roles = "ADMIN")
+├── categories/
+│   ├── CategoryControllerTest.java      # Updated: @WithMockUser(roles = "ADMIN")
+│   └── CategoryIntegrationTest.java     # Updated: @WithMockUser(roles = "ADMIN")
+├── FinalIntegrationTest.java            # Updated: @WithMockUser(roles = "ADMIN")
+└── MoneytrakApplicationTests.java       # Updated: @WithMockUser(roles = "ADMIN")
+```
+
+**Structure Decision**: Feature-based package `security/` under the main application package, consistent with the existing `transactions/` and `categories/` feature packages. Infrastructure concern as allowed by Constitution Principle I.
+
+## Current Implementation Status
+
+The security infrastructure is **already implemented** on this branch. Five source files exist in the `security/` package, dependencies are added to `pom.xml`, and configuration is in both YAML files. However:
+
+**What's done**:
+- `SecurityConfig.java` — SecurityFilterChain with correct authorization rules
+- `SecurityProperties.java` — `@ConfigurationProperties` record
+- `SecurityUserDetailsService.java` — InMemoryUserDetailsManager wired from config
+- `CustomAuthEntryPoint.java` — JSON 401 handler with failed auth logging (FR-014)
+- `CustomAccessDeniedHandler.java` — JSON 403 handler
+- `pom.xml` — `spring-boot-starter-security` and `spring-security-test` added
+- `application.yaml` — 3 users with BCrypt passwords configured
+- `application-test.yaml` — 3 test users with `{noop}` passwords
+- `SecuritySmokeTest.java` — 2 basic tests (auth 200, no-auth 401)
+- Existing test classes have `@WithMockUser(roles = "ADMIN")` at class level
+
+**What's broken** (27 of 31 tests failing with 401):
+- The `@WithMockUser(roles = "ADMIN")` annotation is present on all test classes, but tests using `@AutoConfigureMockMvc` are still getting 401 responses. This indicates a Spring Security 7 / Spring Boot 4 compatibility issue where the auto-configured MockMvc may not be picking up the security context from `@WithMockUser`.
+- The `SecuritySmokeTest` passes because it manually configures MockMvc with `springSecurity()` in `@BeforeEach`.
+
+**What needs to be done**:
+1. Fix the test infrastructure so `@AutoConfigureMockMvc` + `@WithMockUser` works with Spring Security 7
+2. Write comprehensive `SecurityIntegrationTest` covering all acceptance scenarios from the spec
+3. Verify all 5 user stories' acceptance criteria pass
+4. Update CLAUDE.md with the security feature documentation
+
+## Complexity Tracking
+
+No constitution violations to justify — all design decisions align with existing principles.

--- a/specs/003-simple-auth/quickstart.md
+++ b/specs/003-simple-auth/quickstart.md
@@ -1,0 +1,102 @@
+# Quickstart: Simple Role-Based Authentication
+
+**Feature Branch**: `003-simple-auth`
+**Date**: 2026-02-03
+
+## Prerequisites
+
+- Java 25
+- Maven (via wrapper: `./mvnw`)
+- Existing MoneyTrak application running on `003-simple-auth` branch
+
+## New Dependencies
+
+Add to `pom.xml`:
+
+```xml
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-security</artifactId>
+</dependency>
+<dependency>
+    <groupId>org.springframework.security</groupId>
+    <artifactId>spring-security-test</artifactId>
+    <scope>test</scope>
+</dependency>
+```
+
+## Configuration
+
+### Default Users (application.yaml)
+
+```yaml
+moneytrak:
+  security:
+    users:
+      - username: app-client
+        password: "{bcrypt}$2a$10$<hash>"
+        role: APP
+      - username: backoffice
+        password: "{bcrypt}$2a$10$<hash>"
+        role: BACKOFFICE
+      - username: admin
+        password: "{bcrypt}$2a$10$<hash>"
+        role: ADMIN
+```
+
+### Test Users (application-test.yaml)
+
+Tests use simpler credentials. Use `{noop}` prefix for plaintext passwords in test profile for readability.
+
+## Testing the Feature
+
+### Run all tests
+```bash
+./mvnw test
+```
+
+### Manual testing with curl
+
+```bash
+# Unauthenticated (expect 401)
+curl -i http://localhost:8080/v1/transactions
+
+# APP role - read (expect 200)
+curl -i -u app-client:password http://localhost:8080/v1/transactions
+
+# APP role - write (expect 403)
+curl -i -u app-client:password -X POST -H "Content-Type: application/json" \
+  -d '{"description":"Test","amount":10.00,"currency":"USD","date":"2026-01-01T00:00:00Z"}' \
+  http://localhost:8080/v1/transactions
+
+# BACKOFFICE role - write (expect 201)
+curl -i -u backoffice:password -X POST -H "Content-Type: application/json" \
+  -d '{"description":"Test","amount":10.00,"currency":"USD","date":"2026-01-01T00:00:00Z"}' \
+  http://localhost:8080/v1/transactions
+
+# ADMIN role - actuator (expect 200)
+curl -i -u admin:password http://localhost:8080/actuator/info
+
+# Health check - no auth needed (expect 200)
+curl -i http://localhost:8080/actuator/health
+```
+
+## New Source Files
+
+```
+src/main/java/dev/juanvaldivia/moneytrak/
+├── security/
+│   ├── SecurityConfig.java              # SecurityFilterChain beans
+│   ├── SecurityProperties.java          # @ConfigurationProperties binding
+│   ├── SecurityUserDetailsService.java  # Maps config users to UserDetails
+│   ├── CustomAuthEntryPoint.java        # JSON 401 responses
+│   └── CustomAccessDeniedHandler.java   # JSON 403 responses
+```
+
+## Key Design Decisions
+
+1. **HTTP Basic Auth** — simplest mechanism, no token lifecycle management
+2. **Config-defined users** — no database table, no user management endpoints
+3. **URL-based authorization** — rules centralized in SecurityFilterChain, not scattered as annotations
+4. **DelegatingPasswordEncoder** — BCrypt default with future algorithm migration support
+5. **Existing tests updated** — `@WithMockUser(roles = "ADMIN")` added at class level

--- a/specs/003-simple-auth/research.md
+++ b/specs/003-simple-auth/research.md
@@ -1,0 +1,90 @@
+# Research: Simple Role-Based Authentication
+
+**Feature Branch**: `003-simple-auth`
+**Date**: 2026-02-03
+
+## R-001: Spring Security Dependency
+
+**Decision**: Use `spring-boot-starter-security` with no version specified. Spring Boot 4.0.1 manages Spring Security 7.0.2 automatically via the BOM. Add `spring-security-test` for test support.
+
+**Rationale**: Letting the Boot BOM manage the version ensures compatibility across all Spring modules. No manual overrides needed.
+
+**Alternatives considered**:
+- Manual `spring-security-web` + `spring-security-config` dependencies — unnecessary with Boot starter.
+
+## R-002: HTTP Basic Authentication Configuration
+
+**Decision**: Define a `SecurityFilterChain` bean using lambda DSL with `.httpBasic(withDefaults())`. Disable CSRF (stateless REST API). Disable form login.
+
+**Rationale**: HTTP Basic is the simplest standard auth mechanism for server-to-server API communication. Lambda DSL is the only option in Spring Security 7 (non-lambda DSL and `and()` chaining removed).
+
+**Alternatives considered**:
+- JWT/OAuth2 — adds significant complexity (token lifecycle, signing keys, refresh flows). Spec explicitly requests simplicity.
+- Session-based auth — unnecessary for API-only application with no browser clients.
+
+**Key migration notes for Spring Security 7**:
+- `and()` method removed — must use lambda DSL
+- `authorizeRequests()` removed — use `authorizeHttpRequests()`
+- `AntPathRequestMatcher`/`MvcRequestMatcher` removed — use `PathPatternRequestMatcher` (or `requestMatchers(String...)` convenience method)
+
+## R-003: In-Memory User Configuration with Roles
+
+**Decision**: Use `InMemoryUserDetailsManager` with users defined via `@ConfigurationProperties` from `application.yaml`. Map YAML-defined users to `UserDetails` objects with `User.builder()`.
+
+**Rationale**: Satisfies FR-012 (configurable, not hardcoded). `InMemoryUserDetailsManager` is appropriate for small user sets (spec says under 10). `@ConfigurationProperties` provides type-safe binding with IDE autocomplete via the configuration processor already in the project.
+
+**Alternatives considered**:
+- `spring.security.user.name`/`password` — only supports a single user, not sufficient for three roles.
+- Database-backed `UserDetailsService` — overkill for this use case.
+- Direct bean definition with hardcoded users — violates FR-012.
+
+**Critical pitfall**: `.roles("APP")` auto-prepends `ROLE_` → authority becomes `ROLE_APP`. Never pass `roles("ROLE_APP")` which would produce `ROLE_ROLE_APP`.
+
+## R-004: Custom JSON Error Responses
+
+**Decision**: Implement custom `AuthenticationEntryPoint` (401) and `AccessDeniedHandler` (403) that return JSON in the existing `ErrorResponseDto` format `{status, error, message, details[]}`.
+
+**Rationale**: FR-013 requires auth errors to match existing format. Default Spring Security entry point returns HTML/plain text. Custom handlers ensure consistent JSON API responses.
+
+**Wiring**: Set entry point on both `.exceptionHandling()` and `.httpBasic()` configurers. The httpBasic entry point overrides the global one for Basic auth flows.
+
+## R-005: URL-Based vs Method-Level Security
+
+**Decision**: Use URL-based security via `requestMatchers().hasRole()` in `SecurityFilterChain`. No `@PreAuthorize` annotations.
+
+**Rationale**: All authorization decisions map to role + HTTP method + URL pattern. No method-parameter inspection needed. Centralizing rules in SecurityFilterChain keeps them auditable in one place. The role permission matrix translates directly to:
+- `GET /v1/**` → APP, BACKOFFICE, ADMIN
+- `POST|PUT|DELETE /v1/**` → BACKOFFICE, ADMIN
+- `/actuator/**` (except health) → ADMIN only
+
+**Alternatives considered**:
+- `@PreAuthorize` annotations — adds complexity and scatters security rules across controllers. Can be added later if needed.
+
+## R-006: Test Support
+
+**Decision**: Use `@SpringBootTest` + `@AutoConfigureMockMvc` with `httpBasic("user", "password")` request post-processor. Use `@WithMockUser` for simpler role-based tests. Existing 40 tests need credential updates.
+
+**Rationale**: All existing test utilities (`@WithMockUser`, `@WithAnonymousUser`, `httpBasic()`) remain available in Spring Security 7. Existing tests will fail with 401 after security is enabled.
+
+**Migration strategy for existing tests**: Add `@WithMockUser(roles = "ADMIN")` at class level to existing test classes. This is the least-disruptive approach since it can be applied without modifying individual test methods.
+
+## R-007: Actuator Security
+
+**Decision**: Use a single `SecurityFilterChain` with `EndpointRequest` matchers for actuator rules, ordered before application rules. Health endpoint is `permitAll()`, other actuator endpoints require ADMIN role.
+
+**Rationale**: The rule set is simple enough for a single chain. Using `EndpointRequest.to("health")` and `EndpointRequest.toAnyEndpoint()` provides clean actuator matching without hardcoding paths.
+
+**Alternatives considered**:
+- Separate `SecurityFilterChain` with `@Order` — viable but adds complexity for only two actuator rules.
+- Separate management port — operational decision beyond this spec's scope.
+
+## R-008: Password Encoding
+
+**Decision**: Use `DelegatingPasswordEncoder` via `PasswordEncoderFactories.createDelegatingPasswordEncoder()`. Store passwords in YAML with `{bcrypt}` prefix.
+
+**Rationale**: `DelegatingPasswordEncoder` is explicitly recommended by Spring Security. It supports multiple algorithms simultaneously and enables future migration without re-hashing. BCrypt with default strength 10 is the standard.
+
+**Alternatives considered**:
+- `BCryptPasswordEncoder` directly — works but lacks future algorithm flexibility.
+- `{noop}` prefix for plaintext — development/testing only.
+- Argon2 — stronger but more resource-intensive; unnecessary for this use case.

--- a/specs/003-simple-auth/spec.md
+++ b/specs/003-simple-auth/spec.md
@@ -1,0 +1,186 @@
+# Feature Specification: Simple Role-Based Authentication
+
+**Feature Branch**: `003-simple-auth`
+**Created**: 2026-02-03
+**Status**: Draft
+**Input**: User description: "Add simple auth to the application for now, keep it simple. One role for consuming applications and another for admin data." Updated: Three roles - ADMIN, APP, BACKOFFICE.
+
+## Clarifications
+
+### Session 2026-02-03
+
+- Q: Should failed authentication attempts be logged for security monitoring? → A: Yes — log all failed authentication attempts including username, timestamp, and IP address.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Protect All Endpoints with Authentication (Priority: P1)
+
+As a system owner, I need all existing endpoints to require valid credentials before granting access, so that unauthorized parties cannot read or modify financial data.
+
+Currently, the MoneyTrak application exposes all transaction and category endpoints without any authentication. Any client can create, read, update, or delete transactions and categories. This story adds a credential gate in front of every endpoint so that only known clients can interact with the system.
+
+**Why this priority**: Without authentication, the entire application is open to anyone. This is the foundational security layer that all other authorization depends on. No other story delivers value without this one.
+
+**Independent Test**: Can be fully tested by sending requests without credentials and verifying they are rejected, then sending requests with valid credentials and verifying they succeed.
+
+**Acceptance Scenarios**:
+
+1. **Given** a client with no credentials, **When** they send a request to any protected endpoint (e.g., `GET /v1/transactions`), **Then** the system returns a 401 Unauthorized error response.
+2. **Given** a client with valid credentials for any role, **When** they send a request to an endpoint they have access to, **Then** the system processes the request normally and returns the expected response.
+3. **Given** a client with invalid credentials (wrong password), **When** they send a request to any endpoint, **Then** the system returns a 401 Unauthorized error response.
+4. **Given** a client with a malformed or missing authentication header, **When** they send a request, **Then** the system returns a 401 Unauthorized error response.
+
+---
+
+### User Story 2 - APP Role for Consuming Applications (Priority: P2)
+
+As a consuming application (e.g., a mobile app, dashboard, or reporting tool), I need to be able to read transaction and category data without the ability to modify it, so that I can display financial information to users without risk of accidental data changes.
+
+The APP role grants access to all read-only operations: listing transactions, viewing individual transactions, listing categories, viewing individual categories, and accessing summary endpoints. APP clients cannot create, update, or delete any resources.
+
+**Why this priority**: The primary use case for external integrations is reading data. Establishing this role ensures consuming applications have just enough access to fulfill their purpose, following the principle of least privilege.
+
+**Independent Test**: Can be fully tested by authenticating as an APP user and verifying all GET endpoints succeed, then attempting POST/PUT/DELETE operations and verifying they are rejected with a 403 Forbidden error.
+
+**Acceptance Scenarios**:
+
+1. **Given** a client authenticated with the APP role, **When** they request a list of transactions (`GET /v1/transactions`), **Then** the system returns the list of transactions successfully.
+2. **Given** a client authenticated with the APP role, **When** they request transaction summaries (e.g., `GET /v1/transactions/summary/expenses`), **Then** the system returns the summary data successfully.
+3. **Given** a client authenticated with the APP role, **When** they request a list of categories (`GET /v1/categories`), **Then** the system returns the list of categories successfully.
+4. **Given** a client authenticated with the APP role, **When** they request a single transaction or category by ID, **Then** the system returns the resource successfully.
+5. **Given** a client authenticated with the APP role, **When** they attempt to create a transaction (`POST /v1/transactions`), **Then** the system returns a 403 Forbidden error response.
+6. **Given** a client authenticated with the APP role, **When** they attempt to update or delete a transaction, **Then** the system returns a 403 Forbidden error response.
+7. **Given** a client authenticated with the APP role, **When** they attempt to create, update, or delete a category, **Then** the system returns a 403 Forbidden error response.
+
+---
+
+### User Story 3 - BACKOFFICE Role for Data Management (Priority: P2)
+
+As a back-office user, I need full access to create, read, update, and delete transactions and categories, so that I can manage the day-to-day financial data in the system.
+
+The BACKOFFICE role grants full CRUD access to all transaction and category endpoints. Back-office users handle data entry, corrections, and category management as part of regular operations.
+
+**Why this priority**: Same priority as APP because both roles define complementary halves of the access model. Without BACKOFFICE, no one can manage data after authentication is enabled.
+
+**Independent Test**: Can be fully tested by authenticating as a BACKOFFICE user and verifying all CRUD endpoints (GET, POST, PUT, DELETE) succeed for both transactions and categories.
+
+**Acceptance Scenarios**:
+
+1. **Given** a client authenticated with the BACKOFFICE role, **When** they create a transaction (`POST /v1/transactions`), **Then** the system creates the transaction and returns a 201 response with a Location header.
+2. **Given** a client authenticated with the BACKOFFICE role, **When** they read, update, or delete transactions, **Then** the system processes the operation normally.
+3. **Given** a client authenticated with the BACKOFFICE role, **When** they perform any category operation (create, read, update, delete), **Then** the system processes the operation normally.
+4. **Given** a client authenticated with the BACKOFFICE role, **When** they access summary endpoints, **Then** the system returns the data successfully.
+
+---
+
+### User Story 4 - ADMIN Role for Full System Access (Priority: P3)
+
+As a system administrator, I need all the permissions of the BACKOFFICE role plus access to system management capabilities, so that I can oversee the entire application.
+
+The ADMIN role grants everything BACKOFFICE has (full CRUD on transactions and categories) plus access to actuator endpoints (beyond health) for system monitoring and diagnostics. This is the highest privilege role.
+
+**Why this priority**: ADMIN builds on BACKOFFICE. The additional actuator access is valuable for operations but not required for core business functionality.
+
+**Independent Test**: Can be fully tested by authenticating as an ADMIN user and verifying full CRUD access plus actuator endpoint access.
+
+**Acceptance Scenarios**:
+
+1. **Given** a client authenticated with the ADMIN role, **When** they perform any transaction or category operation, **Then** the system processes the operation normally (same as BACKOFFICE).
+2. **Given** a client authenticated with the ADMIN role, **When** they access actuator endpoints (e.g., `/actuator/info`), **Then** the system returns the actuator data successfully.
+3. **Given** a client authenticated with the BACKOFFICE role, **When** they access actuator endpoints (beyond health), **Then** the system returns a 403 Forbidden error response.
+4. **Given** a client authenticated with the APP role, **When** they access actuator endpoints (beyond health), **Then** the system returns a 403 Forbidden error response.
+
+---
+
+### User Story 5 - Health Check Remains Publicly Accessible (Priority: P3)
+
+As an operations team member, I need the health check endpoint to remain accessible without credentials, so that infrastructure monitoring tools can verify the application is running without needing authentication.
+
+The actuator health endpoint must be excluded from authentication requirements so that load balancers, uptime monitors, and deployment pipelines can check application liveness.
+
+**Why this priority**: While not a core feature, this is essential for operational readiness. Without it, deploying the application with authentication would break standard monitoring setups.
+
+**Independent Test**: Can be fully tested by sending a request to the health endpoint without credentials and verifying it returns a successful health status.
+
+**Acceptance Scenarios**:
+
+1. **Given** an unauthenticated client, **When** they request the health endpoint, **Then** the system returns the application health status successfully.
+2. **Given** an unauthenticated client, **When** they request any other endpoint, **Then** the system returns a 401 Unauthorized error response.
+
+---
+
+### Edge Cases
+
+- What happens when an APP user attempts a write operation? The system returns a 403 Forbidden error with a clear message indicating insufficient permissions.
+- What happens when credentials are valid but the role is unrecognized? The system rejects the request as unauthorized.
+- What happens when a request contains expired or tampered credentials? The system rejects the request as unauthorized.
+- How does the system respond to concurrent requests with different roles? Each request is evaluated independently based on its own credentials; no cross-request interference occurs.
+- What happens to existing tests that do not send credentials? They must be updated to include valid credentials appropriate for the operations they perform.
+- What happens if a configured user has no role assigned? The system treats the user as having no permissions and rejects all requests with 403 Forbidden.
+- What happens when there are repeated failed authentication attempts from the same source? The system logs each attempt (username, timestamp, IP) for operator review. Brute-force protection (rate limiting, lockout) is deferred to a future feature.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST require valid credentials for all endpoints except the health check endpoint.
+- **FR-002**: System MUST support three distinct roles: APP, BACKOFFICE, and ADMIN.
+- **FR-003**: The APP role MUST have access to all read-only operations (GET requests) on transactions, categories, and summary endpoints.
+- **FR-004**: The APP role MUST NOT have access to any write operations (POST, PUT, DELETE) on transactions or categories.
+- **FR-005**: The APP role MUST NOT have access to actuator endpoints (beyond health).
+- **FR-006**: The BACKOFFICE role MUST have full CRUD access (GET, POST, PUT, DELETE) to all transaction and category endpoints.
+- **FR-007**: The BACKOFFICE role MUST NOT have access to actuator endpoints (beyond health).
+- **FR-008**: The ADMIN role MUST have full CRUD access to all transaction and category endpoints plus access to all actuator endpoints.
+- **FR-009**: System MUST return a 401 Unauthorized response when no credentials or invalid credentials are provided.
+- **FR-010**: System MUST return a 403 Forbidden response when a client has valid credentials but insufficient permissions for the requested operation.
+- **FR-011**: The health check endpoint MUST remain accessible without credentials.
+- **FR-012**: Credentials (usernames and passwords) MUST be configurable through application configuration, not hardcoded in source code.
+- **FR-013**: Error responses for authentication and authorization failures MUST follow the existing error response format (`{status, error, message, details[]}`).
+- **FR-014**: System MUST log all failed authentication attempts, capturing the attempted username, timestamp, and client IP address.
+
+### Key Entities
+
+- **User/Client**: A known consumer of the system, identified by a username and password, assigned exactly one role (APP, BACKOFFICE, or ADMIN).
+- **Role**: A named permission level that determines which operations a client can perform. Three roles exist:
+  - **APP**: Read-only access to transaction and category data.
+  - **BACKOFFICE**: Full CRUD access to transactions and categories.
+  - **ADMIN**: Full CRUD access plus actuator/system management access.
+
+### Role Permission Matrix
+
+| Operation                        | APP | BACKOFFICE | ADMIN |
+| -------------------------------- | --- | ---------- | ----- |
+| GET /v1/transactions             | Yes | Yes        | Yes   |
+| GET /v1/transactions/{id}        | Yes | Yes        | Yes   |
+| GET /v1/transactions/summary/*   | Yes | Yes        | Yes   |
+| POST /v1/transactions            | No  | Yes        | Yes   |
+| PUT /v1/transactions/{id}        | No  | Yes        | Yes   |
+| DELETE /v1/transactions/{id}     | No  | Yes        | Yes   |
+| GET /v1/categories               | Yes | Yes        | Yes   |
+| GET /v1/categories/{id}          | Yes | Yes        | Yes   |
+| POST /v1/categories              | No  | Yes        | Yes   |
+| PUT /v1/categories/{id}          | No  | Yes        | Yes   |
+| DELETE /v1/categories/{id}       | No  | Yes        | Yes   |
+| GET /actuator/health             | N/A (public) | N/A (public) | N/A (public) |
+| GET /actuator/info (and others)  | No  | No         | Yes   |
+
+## Assumptions
+
+- Authentication will use HTTP Basic Authentication, as the user explicitly requested simplicity and this is the simplest standard mechanism for securing a REST API.
+- Users/clients are defined in application configuration rather than stored in a database. This keeps things simple and avoids the need for user management endpoints.
+- The number of configured users will be small (under 10), so configuration-based user management is adequate.
+- Passwords will be stored in hashed form in the configuration to avoid plaintext secrets.
+- The existing error response format will be reused for authentication/authorization errors for consistency.
+- The H2 console path (`/h2-console`) requires authentication (accessible to ADMIN only) to prevent unauthorized database access.
+- Role names in configuration are case-insensitive (e.g., "admin", "ADMIN", "Admin" all map to the ADMIN role).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of non-health-check endpoints reject unauthenticated requests with a 401 response.
+- **SC-002**: 100% of write operations (POST, PUT, DELETE) return 403 Forbidden when performed by an APP-role client.
+- **SC-003**: 100% of actuator endpoints (beyond health) return 403 Forbidden when performed by APP or BACKOFFICE-role clients.
+- **SC-004**: 100% of operations succeed when performed by a client with sufficient role permissions.
+- **SC-005**: The health check endpoint responds successfully to unauthenticated requests 100% of the time.
+- **SC-006**: All existing functionality continues to work correctly for authenticated users with appropriate roles (zero regression in existing features).

--- a/specs/003-simple-auth/tasks.md
+++ b/specs/003-simple-auth/tasks.md
@@ -1,0 +1,284 @@
+# Tasks: Simple Role-Based Authentication
+
+**Input**: Design documents from `/specs/003-simple-auth/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+**Tests**: Included per constitution Principle III (TDD is NON-NEGOTIABLE). Red-Green-Refactor cycle enforced.
+
+**Organization**: Tasks grouped by user story. Each story is independently testable after its phase completes.
+
+**Current State**: The security infrastructure (5 source files, dependencies, configuration) is already implemented on this branch. However, 27 of 31 existing tests fail with 401 due to a Spring Security 7 / `@AutoConfigureMockMvc` compatibility issue. Tasks below account for this — already-completed work is marked `[x]`, remaining work is marked `[ ]`.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Add Spring Security dependencies and create the security package structure
+
+- [x] T001 Add `spring-boot-starter-security` dependency to `pom.xml`
+- [x] T002 Add `spring-security-test` (scope: test) dependency to `pom.xml`
+- [x] T003 Add test user configuration to `src/test/resources/application-test.yaml` with three users (app-client/APP, backoffice/BACKOFFICE, admin/ADMIN) using `{noop}` passwords
+
+**Checkpoint**: Project compiles with security on classpath. Spring Security auto-config activates.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core security infrastructure that ALL user stories depend on. Must complete before any story work.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [x] T004 [P] Create `SecurityProperties` configuration record in `src/main/java/dev/juanvaldivia/moneytrak/security/SecurityProperties.java` — `@ConfigurationProperties(prefix = "moneytrak.security")` with nested `ConfigUser` record (username, password, role)
+- [x] T005 [P] Create `CustomAuthEntryPoint` in `src/main/java/dev/juanvaldivia/moneytrak/security/CustomAuthEntryPoint.java` — implements `AuthenticationEntryPoint`, returns JSON 401 using `ErrorResponseDto`, logs failed auth attempts at WARN level per FR-014 (username, timestamp, IP)
+- [x] T006 [P] Create `CustomAccessDeniedHandler` in `src/main/java/dev/juanvaldivia/moneytrak/security/CustomAccessDeniedHandler.java` — implements `AccessDeniedHandler`, returns JSON 403 using `ErrorResponseDto`
+- [x] T007 Create `SecurityUserDetailsService` in `src/main/java/dev/juanvaldivia/moneytrak/security/SecurityUserDetailsService.java` — reads users from `SecurityProperties`, maps to `UserDetails` via `User.builder().username().password().roles()`, returns `InMemoryUserDetailsManager`
+- [x] T008 Create `SecurityConfig` in `src/main/java/dev/juanvaldivia/moneytrak/security/SecurityConfig.java` — `@Configuration @EnableWebSecurity` with `SecurityFilterChain` bean: CSRF disabled, form login disabled, HTTP Basic enabled, custom entry point and access denied handler wired, authorization rules for health/actuator/v1 endpoints
+- [x] T009 Add `moneytrak.security.users` section to `src/main/resources/application.yaml` with three users (app-client/APP, backoffice/BACKOFFICE, admin/ADMIN) using `{bcrypt}` hashed passwords
+- [x] T010 Fix existing test classes so `@WithMockUser(roles = "ADMIN")` works with `@AutoConfigureMockMvc` under Spring Security 7 / Spring Boot 4. Currently 27 of 31 tests fail with 401 despite having `@WithMockUser` at class level. The `SecuritySmokeTest` works because it manually configures MockMvc with `springSecurity()`. Investigate whether `@AutoConfigureMockMvc` needs additional configuration or whether tests need to manually build MockMvc with `SecurityMockMvcConfigurers.springSecurity()`. Affected files:
+  - `src/test/java/dev/juanvaldivia/moneytrak/transactions/TransactionControllerTest.java`
+  - `src/test/java/dev/juanvaldivia/moneytrak/categories/CategoryControllerTest.java`
+  - `src/test/java/dev/juanvaldivia/moneytrak/categories/CategoryIntegrationTest.java`
+  - `src/test/java/dev/juanvaldivia/moneytrak/FinalIntegrationTest.java`
+  - `src/test/java/dev/juanvaldivia/moneytrak/MoneytrakApplicationTests.java`
+- [x] T011 Run `./mvnw test` — verify all existing tests pass with security enabled (zero regressions per SC-006). Expected: 31 tests pass, 0 failures.
+
+**Checkpoint**: Foundation ready. Security is active, all existing tests pass, custom error handlers return JSON. User story implementation can now begin.
+
+---
+
+## Phase 3: User Story 1 — Protect All Endpoints with Authentication (Priority: P1) MVP
+
+**Goal**: All endpoints require valid HTTP Basic credentials. Unauthenticated requests return 401 JSON response. Valid credentials grant access.
+
+**Independent Test**: Send requests without credentials → 401. Send requests with valid credentials → success. Send requests with wrong password → 401.
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T012 [US1] Write authentication tests in `src/test/java/dev/juanvaldivia/moneytrak/security/SecurityIntegrationTest.java` — `@SpringBootTest @AutoConfigureMockMvc @ActiveProfiles("test")` test class. Use `httpBasic()` request post-processor from `spring-security-test` for credential injection (not `@WithMockUser`). Tests:
+  1. `unauthenticated_getTransactions_returns401` — `GET /v1/transactions` with no credentials → 401 + JSON body with `status: 401, error: "Unauthorized"`
+  2. `invalidCredentials_getTransactions_returns401` — `GET /v1/transactions` with `httpBasic("wrong", "wrong")` → 401
+  3. `validCredentials_getTransactions_returns200` — `GET /v1/transactions` with `httpBasic("admin", "admin")` → 200
+  4. `malformedAuthHeader_getTransactions_returns401` — request with garbled Authorization header → 401
+  5. `unauthenticated_postTransaction_returns401` — `POST /v1/transactions` with no credentials → 401
+  6. `unauthenticated_getCategories_returns401` — `GET /v1/categories` with no credentials → 401
+
+### Implementation for User Story 1
+
+- [x] T013 [US1] Verify `SecurityConfig` authorization rules in `src/main/java/dev/juanvaldivia/moneytrak/security/SecurityConfig.java` — confirm that the existing config has: `/actuator/health` → `permitAll()`, `/actuator/**` → `hasRole("ADMIN")`, `GET /v1/**` → `hasAnyRole("APP", "BACKOFFICE", "ADMIN")`, `POST/PUT/DELETE /v1/**` → `hasAnyRole("BACKOFFICE", "ADMIN")`, all other → `authenticated()`. If any rule is missing or misordered, fix it.
+- [x] T014 [US1] Run `./mvnw test` — verify T012 tests pass (all 6 authentication tests green) plus all existing tests still pass
+
+**Checkpoint**: US1 complete. All endpoints are protected. Unauthenticated requests get 401 JSON. Valid credentials work. MVP achieved.
+
+---
+
+## Phase 4: User Story 2 — APP Role Read-Only Access (Priority: P2)
+
+**Goal**: APP role can read all `/v1/**` resources but cannot create, update, or delete.
+
+**Independent Test**: Authenticate as APP → GET endpoints succeed. POST/PUT/DELETE → 403 Forbidden JSON.
+
+### Tests for User Story 2
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T015 [US2] Write APP role tests in `src/test/java/dev/juanvaldivia/moneytrak/security/SecurityIntegrationTest.java` — add tests using `httpBasic("app-client", "app-client")`:
+  1. `appRole_getTransactions_returns200` — `GET /v1/transactions` → 200
+  2. `appRole_getCategories_returns200` — `GET /v1/categories` → 200
+  3. `appRole_getTransactionSummaryExpenses_returns200` — `GET /v1/transactions/summary/expenses` → 200
+  4. `appRole_getTransactionSummaryIncome_returns200` — `GET /v1/transactions/summary/income` → 200
+  5. `appRole_postTransaction_returns403` — `POST /v1/transactions` with valid JSON body → 403 + JSON body with `status: 403, error: "Forbidden"`
+  6. `appRole_putTransaction_returns403` — `PUT /v1/transactions/{any-uuid}` → 403
+  7. `appRole_deleteTransaction_returns403` — `DELETE /v1/transactions/{any-uuid}` → 403
+  8. `appRole_postCategory_returns403` — `POST /v1/categories` → 403
+  9. `appRole_putCategory_returns403` — `PUT /v1/categories/{any-uuid}` → 403
+  10. `appRole_deleteCategory_returns403` — `DELETE /v1/categories/{any-uuid}` → 403
+
+### Implementation for User Story 2
+
+- [x] T016 [US2] Verify APP role authorization rules are correctly configured in `SecurityConfig` — the `requestMatchers(HttpMethod.GET, "/v1/**").hasAnyRole("APP", "BACKOFFICE", "ADMIN")` rule should already be in place from T008. Confirm POST/PUT/DELETE rules exclude APP. Fix if needed.
+- [x] T017 [US2] Run `./mvnw test` — verify T015 tests pass (all 10 APP role tests green) plus all previous tests still pass
+
+**Checkpoint**: US2 complete. APP users are read-only. Write attempts get 403.
+
+---
+
+## Phase 5: User Story 3 — BACKOFFICE Role Full CRUD (Priority: P2)
+
+**Goal**: BACKOFFICE role can perform all CRUD operations on transactions and categories but cannot access actuator endpoints.
+
+**Independent Test**: Authenticate as BACKOFFICE → all GET, POST, PUT, DELETE operations on /v1/** succeed. Actuator (beyond health) → 403.
+
+### Tests for User Story 3
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T018 [US3] Write BACKOFFICE role tests in `src/test/java/dev/juanvaldivia/moneytrak/security/SecurityIntegrationTest.java` — add tests using `httpBasic("backoffice", "backoffice")`:
+  1. `backofficeRole_postTransaction_returns201` — `POST /v1/transactions` with valid JSON body → 201 with Location header
+  2. `backofficeRole_getTransactions_returns200` — `GET /v1/transactions` → 200
+  3. `backofficeRole_putTransaction_returns200` — create a transaction, then `PUT /v1/transactions/{id}` with update body → 200
+  4. `backofficeRole_deleteTransaction_returns204` — create a transaction, then `DELETE /v1/transactions/{id}` → 204
+  5. `backofficeRole_postCategory_returns201` — `POST /v1/categories` with valid name → 201
+  6. `backofficeRole_getCategories_returns200` — `GET /v1/categories` → 200
+  7. `backofficeRole_getTransactionSummary_returns200` — `GET /v1/transactions/summary/expenses` → 200
+  8. `backofficeRole_actuatorInfo_returns403` — `GET /actuator/info` → 403 (FR-007)
+
+### Implementation for User Story 3
+
+- [x] T019 [US3] Verify BACKOFFICE authorization rules are already in place in `SecurityConfig` from T008 — `hasAnyRole("BACKOFFICE", "ADMIN")` on POST/PUT/DELETE `/v1/**`. BACKOFFICE is explicitly included in the write rules. No changes expected; this is a verification task.
+- [x] T020 [US3] Run `./mvnw test` — verify T018 tests pass (all 8 BACKOFFICE role tests green) plus all previous tests still pass
+
+**Checkpoint**: US3 complete. BACKOFFICE users have full CRUD. Works alongside APP restrictions.
+
+---
+
+## Phase 6: User Story 4 — ADMIN Role Full System Access (Priority: P3)
+
+**Goal**: ADMIN role gets all BACKOFFICE permissions plus access to actuator endpoints (beyond health) and H2 console.
+
+**Independent Test**: Authenticate as ADMIN → all CRUD works + actuator/info accessible. BACKOFFICE and APP → actuator returns 403.
+
+### Tests for User Story 4
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T021 [US4] Write ADMIN role and actuator tests in `src/test/java/dev/juanvaldivia/moneytrak/security/SecurityIntegrationTest.java` — add tests:
+  1. `adminRole_actuatorInfo_returns200` — `GET /actuator/info` with `httpBasic("admin", "admin")` → 200
+  2. `adminRole_postTransaction_returns201` — `POST /v1/transactions` with ADMIN credentials → 201 (verify ADMIN has BACKOFFICE-level access)
+  3. `adminRole_getTransactions_returns200` — `GET /v1/transactions` with ADMIN credentials → 200
+  4. `appRole_actuatorInfo_returns403` — `GET /actuator/info` with APP credentials → 403 (FR-005)
+
+### Implementation for User Story 4
+
+- [x] T022 [US4] Verify actuator authorization rules are in place in `SecurityConfig` — confirm `requestMatchers("/actuator/**").hasRole("ADMIN")` is ordered after `/actuator/health` permitAll. Also confirm H2 console rules: `requestMatchers("/h2-console/**").hasRole("ADMIN")` with frame options set to sameOrigin. Fix ordering if needed.
+- [x] T023 [US4] Run `./mvnw test` — verify T021 tests pass (all 4 ADMIN/actuator tests green) plus all previous tests still pass
+
+**Checkpoint**: US4 complete. ADMIN has full system access. BACKOFFICE and APP blocked from actuator.
+
+---
+
+## Phase 7: User Story 5 — Health Check Publicly Accessible (Priority: P3)
+
+**Goal**: `/actuator/health` responds to unauthenticated requests. All other endpoints still require auth.
+
+**Independent Test**: No credentials + health endpoint → 200. No credentials + any other endpoint → 401.
+
+### Tests for User Story 5
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T024 [US5] Write health endpoint tests in `src/test/java/dev/juanvaldivia/moneytrak/security/SecurityIntegrationTest.java` — add tests:
+  1. `healthEndpoint_noAuth_returns200` — `GET /actuator/health` with no credentials → 200
+  2. `actuatorInfo_noAuth_returns401` — `GET /actuator/info` with no credentials → 401 (not public)
+  3. `apiEndpoint_noAuth_returns401` — `GET /v1/transactions` with no credentials → 401 (regression check, cross-ref with T012)
+
+### Implementation for User Story 5
+
+- [x] T025 [US5] Verify health endpoint permitAll rule is in place in `SecurityConfig` — confirm `requestMatchers("/actuator/health").permitAll()` is first in the authorization rule chain. Fix if needed.
+- [x] T026 [US5] Run `./mvnw test` — verify T024 tests pass (all 3 health endpoint tests green) plus all previous tests still pass
+
+**Checkpoint**: US5 complete. Health endpoint is public. All other endpoints properly protected.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation, failed auth logging verification, and documentation updates
+
+- [x] T027 Write failed authentication logging test in `src/test/java/dev/juanvaldivia/moneytrak/security/SecurityIntegrationTest.java` — send invalid credentials and verify WARN-level log output contains `Failed authentication attempt:` with username and IP address fields (FR-014)
+- [x] T028 Run full test suite `./mvnw clean test` — verify ALL tests pass (existing tests + all new security tests). Zero regressions per SC-006.
+- [x] T029 Update `CLAUDE.md` to document the security feature — add/update sections covering: three roles (APP, BACKOFFICE, ADMIN), HTTP Basic auth, config-based users, role permission matrix, new `security/` package with 5 classes, test profile credentials, updated test count
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — already complete ✅
+- **Foundational (Phase 2)**: Depends on Setup — T010 is the critical remaining task (fix test infrastructure)
+- **US1 (Phase 3)**: Depends on Foundational (T010-T011) — MVP target
+- **US2 (Phase 4)**: Depends on US1 (T012-T014) — needs verified SecurityConfig
+- **US3 (Phase 5)**: Depends on US2 (T015-T017) — validates BACKOFFICE rules from US2
+- **US4 (Phase 6)**: Depends on US1 (T012-T014) — adds actuator verification (independent of US2/US3)
+- **US5 (Phase 7)**: Depends on US1 (T012-T014) — verifies health permitAll (independent of US2/US3/US4)
+- **Polish (Phase 8)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Foundation → blocks US2, US3, US4, US5
+- **US2 (P2)**: US1 → implements/verifies role-based read-only rules
+- **US3 (P2)**: US2 → verifies BACKOFFICE permissions (rules in place from US2)
+- **US4 (P3)**: US1 → verifies actuator rules (independent of US2/US3)
+- **US5 (P3)**: US1 → verifies health permitAll (independent of US2/US3/US4)
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Implementation verifies/refines SecurityConfig rules
+- Test suite run confirms green + no regressions
+
+### Parallel Opportunities
+
+- **Phase 2**: T004-T006 already done in parallel (different files) ✅
+- **Phase 4 + Phase 6**: US2 and US4 can be parallelized after US1 (different rule sets: /v1/ roles vs actuator roles)
+- **Phase 6 + Phase 7**: US4 and US5 can be parallelized (different concerns: actuator auth vs health public)
+
+---
+
+## Parallel Example: Post-US1 Parallel Execution
+
+```bash
+# After US1 is complete, these can run in parallel:
+
+# Track A: Role-based access (US2 → US3)
+Task: "Write APP role tests in SecurityIntegrationTest.java"
+Task: "Verify APP role rules in SecurityConfig"
+
+# Track B: System access (US4 + US5)
+Task: "Write ADMIN actuator tests in SecurityIntegrationTest.java"
+Task: "Write health endpoint tests in SecurityIntegrationTest.java"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 2: Fix test infrastructure (T010-T011) — critical blocker
+2. Complete Phase 3: US1 — Write auth tests, verify config, run suite
+3. **STOP and VALIDATE**: `./mvnw test` green, verify 401/200 behavior
+4. This is a deployable increment — all endpoints are now protected
+
+### Incremental Delivery
+
+1. Fix tests + US1 → Authentication works → Deploy/Demo (MVP!)
+2. US2 → APP role is read-only → Deploy/Demo
+3. US3 → BACKOFFICE has full CRUD → Deploy/Demo
+4. US4 → ADMIN has actuator access → Deploy/Demo
+5. US5 → Health endpoint public → Deploy/Demo
+6. Polish → Logging verified, docs updated → Final Deploy
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Constitution Principle III requires TDD — all test tasks precede implementation
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Phase 1 (T001-T003) and most of Phase 2 (T004-T009) are already complete
+- **Critical remaining work**: T010 (fix test infrastructure) is the single blocker
+- Total: 29 tasks across 8 phases (9 already complete, 20 remaining)
+- New security tests expected: ~31 tests across all user stories
+- Existing tests to pass: 31 tests (currently 27 failing due to T010)

--- a/src/main/java/dev/juanvaldivia/moneytrak/MoneytrakApplication.java
+++ b/src/main/java/dev/juanvaldivia/moneytrak/MoneytrakApplication.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class MoneytrakApplication {
 
-	public static void main(String[] args) {
+	static void main(String[] args) {
 		SpringApplication.run(MoneytrakApplication.class, args);
 	}
 

--- a/src/main/java/dev/juanvaldivia/moneytrak/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/dev/juanvaldivia/moneytrak/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,40 @@
+package dev.juanvaldivia.moneytrak.security;
+
+import tools.jackson.databind.ObjectMapper;
+import dev.juanvaldivia.moneytrak.exception.ErrorResponseDto;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public CustomAccessDeniedHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        var errorResponse = new ErrorResponseDto(
+                HttpStatus.FORBIDDEN.value(),
+                "Forbidden",
+                "Access denied. Insufficient permissions for this operation.",
+                List.of()
+        );
+
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/src/main/java/dev/juanvaldivia/moneytrak/security/CustomAuthEntryPoint.java
+++ b/src/main/java/dev/juanvaldivia/moneytrak/security/CustomAuthEntryPoint.java
@@ -1,0 +1,52 @@
+package dev.juanvaldivia.moneytrak.security;
+
+import tools.jackson.databind.ObjectMapper;
+import dev.juanvaldivia.moneytrak.exception.ErrorResponseDto;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+@Component
+public class CustomAuthEntryPoint implements AuthenticationEntryPoint {
+
+    private static final Logger log = LoggerFactory.getLogger(CustomAuthEntryPoint.class);
+
+    private final ObjectMapper objectMapper;
+
+    public CustomAuthEntryPoint(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        String username = request.getRemoteUser() != null ? request.getRemoteUser() : "anonymous";
+        String ip = request.getRemoteAddr();
+        String timestamp = ZonedDateTime.now().toString();
+
+        log.warn("Failed authentication attempt: username='{}', ip='{}', timestamp='{}'", username, ip, timestamp);
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setHeader("WWW-Authenticate", "Basic realm=\"MoneyTrak API\"");
+
+        var errorResponse = new ErrorResponseDto(
+                HttpStatus.UNAUTHORIZED.value(),
+                "Unauthorized",
+                "Authentication required. Provide valid credentials.",
+                List.of()
+        );
+
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/src/main/java/dev/juanvaldivia/moneytrak/security/SecurityConfig.java
+++ b/src/main/java/dev/juanvaldivia/moneytrak/security/SecurityConfig.java
@@ -1,0 +1,61 @@
+package dev.juanvaldivia.moneytrak.security;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@Configuration
+@EnableWebSecurity
+@EnableConfigurationProperties(SecurityProperties.class)
+public class SecurityConfig {
+
+    private final CustomAuthEntryPoint customAuthEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final SecurityUserDetailsService securityUserDetailsService;
+
+    public SecurityConfig(CustomAuthEntryPoint customAuthEntryPoint,
+                          CustomAccessDeniedHandler customAccessDeniedHandler,
+                          SecurityUserDetailsService securityUserDetailsService) {
+        this.customAuthEntryPoint = customAuthEntryPoint;
+        this.customAccessDeniedHandler = customAccessDeniedHandler;
+        this.securityUserDetailsService = securityUserDetailsService;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .headers(headers -> headers
+                        .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+                .authorizeHttpRequests(authz -> authz
+                        .requestMatchers("/actuator/health").permitAll()
+                        .requestMatchers("/actuator/**").hasRole("ADMIN")
+                        .requestMatchers("/h2-console/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/v1/**").hasAnyRole("APP", "BACKOFFICE", "ADMIN")
+                        .requestMatchers("/v1/**").hasAnyRole("BACKOFFICE", "ADMIN")
+                        .anyRequest().authenticated()
+                )
+                .httpBasic(basic -> basic
+                        .authenticationEntryPoint(customAuthEntryPoint))
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(customAuthEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler));
+
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        return securityUserDetailsService.getUserDetailsManager();
+    }
+}

--- a/src/main/java/dev/juanvaldivia/moneytrak/security/SecurityProperties.java
+++ b/src/main/java/dev/juanvaldivia/moneytrak/security/SecurityProperties.java
@@ -1,0 +1,11 @@
+package dev.juanvaldivia.moneytrak.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "moneytrak.security")
+public record SecurityProperties(List<ConfigUser> users) {
+
+    public record ConfigUser(String username, String password, String role) {}
+}

--- a/src/main/java/dev/juanvaldivia/moneytrak/security/SecurityUserDetailsService.java
+++ b/src/main/java/dev/juanvaldivia/moneytrak/security/SecurityUserDetailsService.java
@@ -1,0 +1,28 @@
+package dev.juanvaldivia.moneytrak.security;
+
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SecurityUserDetailsService {
+
+    private final InMemoryUserDetailsManager userDetailsManager;
+
+    public SecurityUserDetailsService(SecurityProperties securityProperties) {
+        UserDetails[] users = securityProperties.users().stream()
+                .map(configUser -> User.builder()
+                        .username(configUser.username())
+                        .password(configUser.password())
+                        .roles(configUser.role().toUpperCase())
+                        .build())
+                .toArray(UserDetails[]::new);
+
+        this.userDetailsManager = new InMemoryUserDetailsManager(users);
+    }
+
+    public InMemoryUserDetailsManager getUserDetailsManager() {
+        return userDetailsManager;
+    }
+}

--- a/src/main/java/dev/juanvaldivia/moneytrak/transactions/TransactionController.java
+++ b/src/main/java/dev/juanvaldivia/moneytrak/transactions/TransactionController.java
@@ -56,7 +56,7 @@ public class TransactionController {
      * GET /v1/transactions?categoryId={uuid}&stability={FIXED|VARIABLE}
      *
      * Returns transactions ordered by date descending (newest first).
-     * Supports filtering by categoryId and/or transactionStability.
+     * Supports filtering by categoryId and/or stability.
      * Returns empty array if valid filters have no matching transactions.
      *
      * @param categoryId optional category UUID for filtering

--- a/src/main/java/dev/juanvaldivia/moneytrak/transactions/dto/TransactionCreationDto.java
+++ b/src/main/java/dev/juanvaldivia/moneytrak/transactions/dto/TransactionCreationDto.java
@@ -19,8 +19,8 @@ import java.util.UUID;
  * @param amount positive amount (required)
  * @param currency ISO 4217 currency code (required)
  * @param date transaction date (required, not in future)
- * @param transactionType EXPENSE or INCOME (optional, defaults to EXPENSE)
- * @param transactionStability FIXED or VARIABLE (optional, defaults to VARIABLE)
+ * @param type EXPENSE or INCOME (optional, defaults to EXPENSE)
+ * @param stability FIXED or VARIABLE (optional, defaults to VARIABLE)
  * @param categoryId category UUID (optional, defaults to "Others")
  */
 public record TransactionCreationDto(
@@ -41,9 +41,9 @@ public record TransactionCreationDto(
     @PastOrPresent(message = "Date must not be in the future")
     ZonedDateTime date,
 
-    TransactionType transactionType,
+    TransactionType type,
 
-    TransactionStability transactionStability,
+    TransactionStability stability,
 
     UUID categoryId
 ) {

--- a/src/main/java/dev/juanvaldivia/moneytrak/transactions/dto/TransactionDto.java
+++ b/src/main/java/dev/juanvaldivia/moneytrak/transactions/dto/TransactionDto.java
@@ -16,8 +16,8 @@ import java.util.UUID;
  * @param amount positive amount
  * @param currency ISO 4217 currency code
  * @param date transaction date
- * @param transactionType EXPENSE or INCOME
- * @param transactionStability FIXED or VARIABLE
+ * @param type EXPENSE or INCOME
+ * @param stability FIXED or VARIABLE
  * @param categoryId linked category ID
  * @param categoryName linked category name
  * @param version optimistic locking version
@@ -30,8 +30,8 @@ public record TransactionDto(
     BigDecimal amount,
     String currency,
     ZonedDateTime date,
-    TransactionType transactionType,
-    TransactionStability transactionStability,
+    TransactionType type,
+    TransactionStability stability,
     UUID categoryId,
     String categoryName,
     Integer version,

--- a/src/main/java/dev/juanvaldivia/moneytrak/transactions/dto/TransactionUpdateDto.java
+++ b/src/main/java/dev/juanvaldivia/moneytrak/transactions/dto/TransactionUpdateDto.java
@@ -17,8 +17,8 @@ import java.util.UUID;
  * @param amount new amount (optional)
  * @param currency new currency (optional)
  * @param date new date (optional)
- * @param transactionType new type EXPENSE/INCOME (optional)
- * @param transactionStability new stability FIXED/VARIABLE (optional)
+ * @param type new type EXPENSE/INCOME (optional)
+ * @param stability new stability FIXED/VARIABLE (optional)
  * @param categoryId new category ID (optional)
  * @param version current version for optimistic locking (required)
  */
@@ -36,9 +36,9 @@ public record TransactionUpdateDto(
     @PastOrPresent(message = "Date must not be in the future")
     ZonedDateTime date,
 
-    TransactionType transactionType,
+    TransactionType type,
 
-    TransactionStability transactionStability,
+    TransactionStability stability,
 
     UUID categoryId,
 

--- a/src/main/java/dev/juanvaldivia/moneytrak/transactions/mapper/TransactionMapper.java
+++ b/src/main/java/dev/juanvaldivia/moneytrak/transactions/mapper/TransactionMapper.java
@@ -30,8 +30,8 @@ public class TransactionMapper {
             dto.amount(),
             dto.currency(),
             dto.date(),
-            dto.transactionType() != null ? dto.transactionType() : TransactionType.EXPENSE,
-            dto.transactionStability() != null ? dto.transactionStability() : TransactionStability.VARIABLE,
+            dto.type() != null ? dto.type() : TransactionType.EXPENSE,
+            dto.stability() != null ? dto.stability() : TransactionStability.VARIABLE,
             category
         );
     }
@@ -51,8 +51,8 @@ public class TransactionMapper {
             dto.amount() != null ? dto.amount() : existing.amount(),
             dto.currency() != null ? dto.currency() : existing.currency(),
             dto.date() != null ? dto.date() : existing.date(),
-            dto.transactionType() != null ? dto.transactionType() : existing.transactionType(),
-            dto.transactionStability() != null ? dto.transactionStability() : existing.transactionStability(),
+            dto.type() != null ? dto.type() : existing.transactionType(),
+            dto.stability() != null ? dto.stability() : existing.transactionStability(),
             newCategory != null ? newCategory : existing.category()
         );
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,6 +21,28 @@ spring:
       hibernate:
         format_sql: true
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      show-details: never
+
+moneytrak:
+  security:
+    users:
+      - username: app-client
+        password: "{bcrypt}$2a$10$GRLdNijSQMUvl/au9ofL.eDwmoohzzS7.rmNSJZ.0FxO/BTk76klW"
+        role: APP
+      - username: backoffice
+        password: "{bcrypt}$2a$10$GRLdNijSQMUvl/au9ofL.eDwmoohzzS7.rmNSJZ.0FxO/BTk76klW"
+        role: BACKOFFICE
+      - username: admin
+        password: "{bcrypt}$2a$10$GRLdNijSQMUvl/au9ofL.eDwmoohzzS7.rmNSJZ.0FxO/BTk76klW"
+        role: ADMIN
+
 logging:
   level:
     org.springframework.boot.autoconfigure.h2: DEBUG

--- a/src/test/java/dev/juanvaldivia/moneytrak/FinalIntegrationTest.java
+++ b/src/test/java/dev/juanvaldivia/moneytrak/FinalIntegrationTest.java
@@ -87,8 +87,8 @@ class FinalIntegrationTest {
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.categoryId").value(categoryId))
             .andExpect(jsonPath("$.categoryName").value("Medical"))
-            .andExpect(jsonPath("$.transactionType").value("EXPENSE"))
-            .andExpect(jsonPath("$.transactionStability").value("VARIABLE"))
+            .andExpect(jsonPath("$.type").value("EXPENSE"))
+            .andExpect(jsonPath("$.stability").value("VARIABLE"))
             .andReturn().getResponse().getContentAsString();
 
         String transactionId = extractId(createTxResponse);
@@ -112,12 +112,12 @@ class FinalIntegrationTest {
                         "amount": 500.00,
                         "currency": "EUR",
                         "date": "2026-01-20T10:00:00Z",
-                        "transactionType": "INCOME",
-                        "transactionStability": "VARIABLE"
+                        "type": "INCOME",
+                        "stability": "VARIABLE"
                     }
                     """))
             .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.transactionType").value("INCOME"));
+            .andExpect(jsonPath("$.type").value("INCOME"));
 
         // Verify expense total
         mockMvc.perform(get("/v1/transactions/summary/expenses"))
@@ -142,12 +142,12 @@ class FinalIntegrationTest {
                         "amount": 12.99,
                         "currency": "EUR",
                         "date": "2026-01-01T00:00:00Z",
-                        "transactionType": "EXPENSE",
-                        "transactionStability": "FIXED"
+                        "type": "EXPENSE",
+                        "stability": "FIXED"
                     }
                     """))
             .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.transactionStability").value("FIXED"));
+            .andExpect(jsonPath("$.stability").value("FIXED"));
 
         // Filter by FIXED stability
         mockMvc.perform(get("/v1/transactions?stability=FIXED"))

--- a/src/test/java/dev/juanvaldivia/moneytrak/FinalIntegrationTest.java
+++ b/src/test/java/dev/juanvaldivia/moneytrak/FinalIntegrationTest.java
@@ -15,6 +15,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 
+import org.springframework.security.test.context.support.WithMockUser;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -32,6 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @Transactional
+@WithMockUser(roles = "ADMIN")
 class FinalIntegrationTest {
 
     @Autowired

--- a/src/test/java/dev/juanvaldivia/moneytrak/MoneytrakApplicationTests.java
+++ b/src/test/java/dev/juanvaldivia/moneytrak/MoneytrakApplicationTests.java
@@ -2,8 +2,10 @@ package dev.juanvaldivia.moneytrak;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
 
 @SpringBootTest
+@WithMockUser(roles = "ADMIN")
 class MoneytrakApplicationTests {
 
 	@Test

--- a/src/test/java/dev/juanvaldivia/moneytrak/categories/CategoryControllerTest.java
+++ b/src/test/java/dev/juanvaldivia/moneytrak/categories/CategoryControllerTest.java
@@ -6,6 +6,7 @@ import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @Transactional
+@WithMockUser(roles = "ADMIN")
 class CategoryControllerTest {
 
     @Autowired

--- a/src/test/java/dev/juanvaldivia/moneytrak/categories/CategoryIntegrationTest.java
+++ b/src/test/java/dev/juanvaldivia/moneytrak/categories/CategoryIntegrationTest.java
@@ -5,6 +5,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import org.springframework.security.test.context.support.WithMockUser;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -13,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @SpringBootTest
 @ActiveProfiles("test")
+@WithMockUser(roles = "ADMIN")
 class CategoryIntegrationTest {
 
     @Autowired

--- a/src/test/java/dev/juanvaldivia/moneytrak/security/SecurityIntegrationTest.java
+++ b/src/test/java/dev/juanvaldivia/moneytrak/security/SecurityIntegrationTest.java
@@ -1,0 +1,372 @@
+package dev.juanvaldivia.moneytrak.security;
+
+import dev.juanvaldivia.moneytrak.categories.CategoryRepository;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Comprehensive security integration tests covering all 5 user stories.
+ * Uses httpBasic() post-processor with real configured test users
+ * from application-test.yaml (not @WithMockUser).
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class SecurityIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    private static final String VALID_TRANSACTION_JSON = """
+            {
+                "description": "Test transaction",
+                "amount": 10.00,
+                "currency": "EUR",
+                "date": "2026-01-15T12:00:00Z",
+                "transactionType": "EXPENSE"
+            }
+            """;
+
+    // ========================================================================
+    // US1: Protect All Endpoints with Authentication (P1)
+    // ========================================================================
+
+    @Nested
+    class US1_Authentication {
+
+        @Test
+        void unauthenticated_getTransactions_returns401() throws Exception {
+            mockMvc.perform(get("/v1/transactions"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value(401))
+                    .andExpect(jsonPath("$.error").value("Unauthorized"));
+        }
+
+        @Test
+        void invalidCredentials_getTransactions_returns401() throws Exception {
+            mockMvc.perform(get("/v1/transactions")
+                            .with(httpBasic("wrong", "wrong")))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void validCredentials_getTransactions_returns200() throws Exception {
+            mockMvc.perform(get("/v1/transactions")
+                            .with(httpBasic("admin", "admin")))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void malformedAuthHeader_getTransactions_returns401() throws Exception {
+            mockMvc.perform(get("/v1/transactions")
+                            .header("Authorization", "Basic not-valid-base64!!!"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void unauthenticated_postTransaction_returns401() throws Exception {
+            mockMvc.perform(post("/v1/transactions")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(VALID_TRANSACTION_JSON))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void unauthenticated_getCategories_returns401() throws Exception {
+            mockMvc.perform(get("/v1/categories"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    // ========================================================================
+    // US2: APP Role Read-Only Access (P2)
+    // ========================================================================
+
+    @Nested
+    class US2_AppRole {
+
+        @Test
+        void appRole_getTransactions_returns200() throws Exception {
+            mockMvc.perform(get("/v1/transactions")
+                            .with(httpBasic("app-client", "app-client")))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void appRole_getCategories_returns200() throws Exception {
+            mockMvc.perform(get("/v1/categories")
+                            .with(httpBasic("app-client", "app-client")))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void appRole_getTransactionSummaryExpenses_returns200() throws Exception {
+            mockMvc.perform(get("/v1/transactions/summary/expenses")
+                            .with(httpBasic("app-client", "app-client")))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void appRole_getTransactionSummaryIncome_returns200() throws Exception {
+            mockMvc.perform(get("/v1/transactions/summary/income")
+                            .with(httpBasic("app-client", "app-client")))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void appRole_postTransaction_returns403() throws Exception {
+            mockMvc.perform(post("/v1/transactions")
+                            .with(httpBasic("app-client", "app-client"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(VALID_TRANSACTION_JSON))
+                    .andExpect(status().isForbidden())
+                    .andExpect(jsonPath("$.status").value(403))
+                    .andExpect(jsonPath("$.error").value("Forbidden"));
+        }
+
+        @Test
+        void appRole_putTransaction_returns403() throws Exception {
+            mockMvc.perform(put("/v1/transactions/{id}", UUID.randomUUID())
+                            .with(httpBasic("app-client", "app-client"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"version\": 0}"))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        void appRole_deleteTransaction_returns403() throws Exception {
+            mockMvc.perform(delete("/v1/transactions/{id}", UUID.randomUUID())
+                            .with(httpBasic("app-client", "app-client")))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        void appRole_postCategory_returns403() throws Exception {
+            mockMvc.perform(post("/v1/categories")
+                            .with(httpBasic("app-client", "app-client"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"name\": \"TestCategory\"}"))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        void appRole_putCategory_returns403() throws Exception {
+            mockMvc.perform(put("/v1/categories/{id}", UUID.randomUUID())
+                            .with(httpBasic("app-client", "app-client"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"name\": \"Updated\", \"version\": 0}"))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        void appRole_deleteCategory_returns403() throws Exception {
+            mockMvc.perform(delete("/v1/categories/{id}", UUID.randomUUID())
+                            .with(httpBasic("app-client", "app-client")))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ========================================================================
+    // US3: BACKOFFICE Role Full CRUD (P2)
+    // ========================================================================
+
+    @Nested
+    class US3_BackofficeRole {
+
+        @Test
+        void backofficeRole_postTransaction_returns201() throws Exception {
+            mockMvc.perform(post("/v1/transactions")
+                            .with(httpBasic("backoffice", "backoffice"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(VALID_TRANSACTION_JSON))
+                    .andExpect(status().isCreated())
+                    .andExpect(header().exists("Location"));
+        }
+
+        @Test
+        void backofficeRole_getTransactions_returns200() throws Exception {
+            mockMvc.perform(get("/v1/transactions")
+                            .with(httpBasic("backoffice", "backoffice")))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void backofficeRole_putTransaction_returns200() throws Exception {
+            // Create transaction first
+            String response = mockMvc.perform(post("/v1/transactions")
+                            .with(httpBasic("backoffice", "backoffice"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(VALID_TRANSACTION_JSON))
+                    .andExpect(status().isCreated())
+                    .andReturn().getResponse().getContentAsString();
+
+            String txId = extractId(response);
+
+            // Update it
+            mockMvc.perform(put("/v1/transactions/{id}", txId)
+                            .with(httpBasic("backoffice", "backoffice"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"description\": \"Updated\", \"version\": 0}"))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void backofficeRole_deleteTransaction_returns204() throws Exception {
+            // Create transaction first
+            String response = mockMvc.perform(post("/v1/transactions")
+                            .with(httpBasic("backoffice", "backoffice"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(VALID_TRANSACTION_JSON))
+                    .andExpect(status().isCreated())
+                    .andReturn().getResponse().getContentAsString();
+
+            String txId = extractId(response);
+
+            // Delete it
+            mockMvc.perform(delete("/v1/transactions/{id}", txId)
+                            .with(httpBasic("backoffice", "backoffice")))
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        void backofficeRole_postCategory_returns201() throws Exception {
+            mockMvc.perform(post("/v1/categories")
+                            .with(httpBasic("backoffice", "backoffice"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("{\"name\": \"BackofficeTestCategory\"}"))
+                    .andExpect(status().isCreated());
+        }
+
+        @Test
+        void backofficeRole_getCategories_returns200() throws Exception {
+            mockMvc.perform(get("/v1/categories")
+                            .with(httpBasic("backoffice", "backoffice")))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void backofficeRole_getTransactionSummary_returns200() throws Exception {
+            mockMvc.perform(get("/v1/transactions/summary/expenses")
+                            .with(httpBasic("backoffice", "backoffice")))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void backofficeRole_actuatorInfo_returns403() throws Exception {
+            mockMvc.perform(get("/actuator/info")
+                            .with(httpBasic("backoffice", "backoffice")))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ========================================================================
+    // US4: ADMIN Role Full System Access (P3)
+    // ========================================================================
+
+    @Nested
+    class US4_AdminRole {
+
+        @Test
+        void adminRole_actuatorInfo_returns200() throws Exception {
+            mockMvc.perform(get("/actuator/info")
+                            .with(httpBasic("admin", "admin")))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void adminRole_postTransaction_returns201() throws Exception {
+            mockMvc.perform(post("/v1/transactions")
+                            .with(httpBasic("admin", "admin"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(VALID_TRANSACTION_JSON))
+                    .andExpect(status().isCreated());
+        }
+
+        @Test
+        void adminRole_getTransactions_returns200() throws Exception {
+            mockMvc.perform(get("/v1/transactions")
+                            .with(httpBasic("admin", "admin")))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void appRole_actuatorInfo_returns403() throws Exception {
+            mockMvc.perform(get("/actuator/info")
+                            .with(httpBasic("app-client", "app-client")))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ========================================================================
+    // US5: Health Check Publicly Accessible (P3)
+    // ========================================================================
+
+    @Nested
+    class US5_HealthCheck {
+
+        @Test
+        void healthEndpoint_noAuth_returns200() throws Exception {
+            mockMvc.perform(get("/actuator/health"))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void actuatorInfo_noAuth_returns401() throws Exception {
+            mockMvc.perform(get("/actuator/info"))
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        void apiEndpoint_noAuth_returns401() throws Exception {
+            mockMvc.perform(get("/v1/transactions"))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    // ========================================================================
+    // FR-014: Failed Authentication Logging
+    // ========================================================================
+
+    @Nested
+    class FailedAuthLogging {
+
+        @Test
+        void failedAuth_returns401WithCorrectFormat() throws Exception {
+            mockMvc.perform(get("/v1/transactions")
+                            .with(httpBasic("unknown-user", "bad-password")))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value(401))
+                    .andExpect(jsonPath("$.error").value("Unauthorized"))
+                    .andExpect(jsonPath("$.message").value("Authentication required. Provide valid credentials."))
+                    .andExpect(jsonPath("$.details").isEmpty())
+                    .andExpect(header().string("WWW-Authenticate", "Basic realm=\"MoneyTrak API\""));
+        }
+    }
+
+    // ========================================================================
+    // Helper
+    // ========================================================================
+
+    private String extractId(String jsonResponse) {
+        int idStart = jsonResponse.indexOf("\"id\":\"") + 6;
+        int idEnd = jsonResponse.indexOf("\"", idStart);
+        return jsonResponse.substring(idStart, idEnd);
+    }
+}

--- a/src/test/java/dev/juanvaldivia/moneytrak/security/SecuritySmokeTest.java
+++ b/src/test/java/dev/juanvaldivia/moneytrak/security/SecuritySmokeTest.java
@@ -1,0 +1,46 @@
+package dev.juanvaldivia.moneytrak.security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class SecuritySmokeTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setup() {
+        mockMvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void withMockUser_getCategories_shouldReturn200() throws Exception {
+        mockMvc.perform(get("/v1/categories"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void noAuth_getCategories_shouldReturn401() throws Exception {
+        mockMvc.perform(get("/v1/categories"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/dev/juanvaldivia/moneytrak/transactions/TransactionControllerTest.java
+++ b/src/test/java/dev/juanvaldivia/moneytrak/transactions/TransactionControllerTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @Transactional
+@WithMockUser(roles = "ADMIN")
 class TransactionControllerTest {
 
     @Autowired

--- a/src/test/java/dev/juanvaldivia/moneytrak/transactions/TransactionControllerTest.java
+++ b/src/test/java/dev/juanvaldivia/moneytrak/transactions/TransactionControllerTest.java
@@ -54,7 +54,7 @@ class TransactionControllerTest {
                         "currency": "EUR",
                         "date": "2026-01-15T12:00:00Z",
                         "transactionType": "EXPENSE",
-                        "transactionStability": "VARIABLE",
+                        "stability": "VARIABLE",
                         "categoryId": "%s"
                     }
                     """.formatted(foodCategory.getId())))
@@ -81,7 +81,7 @@ class TransactionControllerTest {
                         "currency": "EUR",
                         "date": "2026-01-10T08:00:00Z",
                         "transactionType": "EXPENSE",
-                        "transactionStability": "VARIABLE",
+                        "stability": "VARIABLE",
                         "categoryId": "%s"
                     }
                     """.formatted(tollsCategory.getId())))
@@ -206,11 +206,11 @@ class TransactionControllerTest {
                         "amount": 30.75,
                         "currency": "EUR",
                         "date": "2026-01-12T00:00:00Z",
-                        "transactionType": "EXPENSE"
+                        "type": "EXPENSE"
                     }
                     """))
             .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.transactionType").value("EXPENSE"))
+            .andExpect(jsonPath("$.type").value("EXPENSE"))
             .andExpect(jsonPath("$.amount").value(30.75));
     }
 
@@ -225,11 +225,11 @@ class TransactionControllerTest {
                         "amount": 500.00,
                         "currency": "EUR",
                         "date": "2026-01-15T00:00:00Z",
-                        "transactionType": "INCOME"
+                        "type": "INCOME"
                     }
                     """))
             .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.transactionType").value("INCOME"))
+            .andExpect(jsonPath("$.type").value("INCOME"))
             .andExpect(jsonPath("$.amount").value(500.00));
     }
 
@@ -244,7 +244,7 @@ class TransactionControllerTest {
                         "amount": -30.75,
                         "currency": "EUR",
                         "date": "2026-01-12T00:00:00Z",
-                        "transactionType": "EXPENSE"
+                        "type": "EXPENSE"
                     }
                     """))
             .andExpect(status().isBadRequest())
@@ -263,7 +263,7 @@ class TransactionControllerTest {
                         "amount": 50.00,
                         "currency": "EUR",
                         "date": "2026-01-10T00:00:00Z",
-                        "transactionType": "EXPENSE"
+                        "type": "EXPENSE"
                     }
                     """))
             .andExpect(status().isCreated());
@@ -277,7 +277,7 @@ class TransactionControllerTest {
                         "amount": 3000.00,
                         "currency": "EUR",
                         "date": "2026-01-01T00:00:00Z",
-                        "transactionType": "INCOME"
+                        "type": "INCOME"
                     }
                     """))
             .andExpect(status().isCreated());
@@ -300,7 +300,7 @@ class TransactionControllerTest {
                         "amount": 200.00,
                         "currency": "EUR",
                         "date": "2026-01-05T00:00:00Z",
-                        "transactionType": "INCOME"
+                        "type": "INCOME"
                     }
                     """))
             .andExpect(status().isCreated());
@@ -314,7 +314,7 @@ class TransactionControllerTest {
                         "amount": 4.50,
                         "currency": "EUR",
                         "date": "2026-01-05T10:00:00Z",
-                        "transactionType": "EXPENSE"
+                        "type": "EXPENSE"
                     }
                     """))
             .andExpect(status().isCreated());
@@ -336,7 +336,7 @@ class TransactionControllerTest {
                         "amount": 25.00,
                         "currency": "EUR",
                         "date": "2026-01-18T00:00:00Z",
-                        "transactionType": "EXPENSE"
+                        "type": "EXPENSE"
                     }
                     """))
             .andExpect(status().isCreated())
@@ -348,12 +348,12 @@ class TransactionControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("""
                     {
-                        "transactionType": "INCOME",
+                        "type": "INCOME",
                         "version": 0
                     }
                     """))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.transactionType").value("INCOME"))
+            .andExpect(jsonPath("$.type").value("INCOME"))
             .andExpect(jsonPath("$.amount").value(25.00));
     }
 
@@ -374,14 +374,14 @@ class TransactionControllerTest {
                         "amount": 12.99,
                         "currency": "EUR",
                         "date": "2026-01-01T00:00:00Z",
-                        "transactionType": "EXPENSE",
-                        "transactionStability": "FIXED",
+                        "type": "EXPENSE",
+                        "stability": "FIXED",
                         "categoryId": "%s"
                     }
                     """.formatted(subscriptions.getId())))
             .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.transactionType").value("EXPENSE"))
-            .andExpect(jsonPath("$.transactionStability").value("FIXED"));
+            .andExpect(jsonPath("$.type").value("EXPENSE"))
+            .andExpect(jsonPath("$.stability").value("FIXED"));
     }
 
     // T063: Creating EXPENSE transaction with VARIABLE stability
@@ -397,14 +397,14 @@ class TransactionControllerTest {
                         "amount": 55.00,
                         "currency": "EUR",
                         "date": "2026-01-14T09:00:00Z",
-                        "transactionType": "EXPENSE",
-                        "transactionStability": "VARIABLE",
+                        "type": "EXPENSE",
+                        "stability": "VARIABLE",
                         "categoryId": "%s"
                     }
                     """.formatted(gas.getId())))
             .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.transactionType").value("EXPENSE"))
-            .andExpect(jsonPath("$.transactionStability").value("VARIABLE"));
+            .andExpect(jsonPath("$.type").value("EXPENSE"))
+            .andExpect(jsonPath("$.stability").value("VARIABLE"));
     }
 
     // T064: Creating INCOME transaction with FIXED stability
@@ -420,14 +420,14 @@ class TransactionControllerTest {
                         "amount": 3000.00,
                         "currency": "EUR",
                         "date": "2026-01-01T00:00:00Z",
-                        "transactionType": "INCOME",
-                        "transactionStability": "FIXED",
+                        "type": "INCOME",
+                        "stability": "FIXED",
                         "categoryId": "%s"
                     }
                     """.formatted(transfers.getId())))
             .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.transactionType").value("INCOME"))
-            .andExpect(jsonPath("$.transactionStability").value("FIXED"));
+            .andExpect(jsonPath("$.type").value("INCOME"))
+            .andExpect(jsonPath("$.stability").value("FIXED"));
     }
 
     // T065: Default stability being VARIABLE when not specified
@@ -441,11 +441,11 @@ class TransactionControllerTest {
                         "amount": 99.99,
                         "currency": "EUR",
                         "date": "2026-01-20T16:00:00Z",
-                        "transactionType": "EXPENSE"
+                        "type": "EXPENSE"
                     }
                     """))
             .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.transactionStability").value("VARIABLE"));
+            .andExpect(jsonPath("$.stability").value("VARIABLE"));
     }
 
     // T066: Filtering transactions by FIXED stability
@@ -460,8 +460,8 @@ class TransactionControllerTest {
                         "amount": 800.00,
                         "currency": "EUR",
                         "date": "2026-01-01T00:00:00Z",
-                        "transactionType": "EXPENSE",
-                        "transactionStability": "FIXED"
+                        "type": "EXPENSE",
+                        "stability": "FIXED"
                     }
                     """))
             .andExpect(status().isCreated());
@@ -475,8 +475,8 @@ class TransactionControllerTest {
                         "amount": 15.00,
                         "currency": "EUR",
                         "date": "2026-01-15T10:00:00Z",
-                        "transactionType": "EXPENSE",
-                        "transactionStability": "VARIABLE"
+                        "type": "EXPENSE",
+                        "stability": "VARIABLE"
                     }
                     """))
             .andExpect(status().isCreated());
@@ -485,7 +485,7 @@ class TransactionControllerTest {
         mockMvc.perform(get("/v1/transactions?stability=FIXED"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.length()").value(1))
-            .andExpect(jsonPath("$[0].transactionStability").value("FIXED"))
+            .andExpect(jsonPath("$[0].stability").value("FIXED"))
             .andExpect(jsonPath("$[0].description").value("Rent payment"));
     }
 
@@ -500,12 +500,12 @@ class TransactionControllerTest {
                         "amount": 120.00,
                         "currency": "EUR",
                         "date": "2026-01-01T00:00:00Z",
-                        "transactionType": "EXPENSE",
-                        "transactionStability": "FIXED"
+                        "type": "EXPENSE",
+                        "stability": "FIXED"
                     }
                     """))
             .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.transactionStability").value("FIXED"))
+            .andExpect(jsonPath("$.stability").value("FIXED"))
             .andReturn().getResponse().getContentAsString();
 
         String txId = extractId(response);
@@ -514,12 +514,12 @@ class TransactionControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("""
                     {
-                        "transactionStability": "VARIABLE",
+                        "stability": "VARIABLE",
                         "version": 0
                     }
                     """))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$.transactionStability").value("VARIABLE"));
+            .andExpect(jsonPath("$.stability").value("VARIABLE"));
     }
 
     // ========================================================================

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -4,3 +4,16 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop  # Clean database per test
+
+moneytrak:
+  security:
+    users:
+      - username: app-client
+        password: "{noop}app-client"
+        role: APP
+      - username: backoffice
+        password: "{noop}backoffice"
+        role: BACKOFFICE
+      - username: admin
+        password: "{noop}admin"
+        role: ADMIN


### PR DESCRIPTION
   Add Spring Security 7 with HTTP Basic Authentication and three
   configurable roles (APP, BACKOFFICE, ADMIN) to protect all API
   endpoints. Users are defined in application.yaml with BCrypt-hashed
   passwords — no database changes required.

   - APP: read-only access to /v1/** (GET only)
   - BACKOFFICE: full CRUD on /v1/** transactions and categories
   - ADMIN: full CRUD + actuator endpoints + H2 console
   - Health endpoint (/actuator/health) remains publicly accessible
   - Custom JSON error responses (401/403) match existing ErrorResponseDto
   - Failed auth attempts logged at WARN level (username, IP, timestamp)
   - 32 new security integration tests, 63 total tests passing
   - Fix: use spring-boot-starter-security-test for Spring Boot 4 MockMvc
